### PR TITLE
Swift 3 changes

### DIFF
--- a/API-Sandbox.xcodeproj/project.pbxproj
+++ b/API-Sandbox.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -340,6 +341,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Pods/Alamofire/Source/Alamofire.swift
+++ b/Pods/Alamofire/Source/Alamofire.swift
@@ -51,7 +51,7 @@ extension String: URLStringConvertible {
 
 extension NSURL: URLStringConvertible {
     public var URLString: String {
-        return absoluteString
+        return absoluteString!
     }
 }
 

--- a/Pods/Alamofire/Source/Download.swift
+++ b/Pods/Alamofire/Source/Download.swift
@@ -154,7 +154,7 @@ extension Request {
             let directoryURLs = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: domain)
 
             if !directoryURLs.isEmpty {
-                return directoryURLs[0].URLByAppendingPathComponent(response.suggestedFilename!)
+                return directoryURLs[0].URLByAppendingPathComponent(response.suggestedFilename!)!
             }
 
             return temporaryURL

--- a/Pods/Alamofire/Source/ServerTrustPolicy.swift
+++ b/Pods/Alamofire/Source/ServerTrustPolicy.swift
@@ -239,13 +239,13 @@ public enum ServerTrustPolicy {
 
     private func trustIsValid(trust: SecTrust) -> Bool {
         var isValid = false
-
-        var result = SecTrustResultType(kSecTrustResultInvalid)
-        let status = SecTrustEvaluate(trust, &result)
+        
+        var result = SecTrustResultType(rawValue: SecTrustResultType.Invalid.rawValue)
+        let status = SecTrustEvaluate(trust, &result!)
 
         if status == errSecSuccess {
-            let unspecified = SecTrustResultType(kSecTrustResultUnspecified)
-            let proceed = SecTrustResultType(kSecTrustResultProceed)
+            let unspecified = SecTrustResultType(rawValue: SecTrustResultType.Unspecified.rawValue)
+            let proceed = SecTrustResultType(rawValue: SecTrustResultType.Proceed.rawValue)
 
             isValid = result == unspecified || result == proceed
         }

--- a/Pods/Alamofire/Source/Upload.swift
+++ b/Pods/Alamofire/Source/Upload.swift
@@ -312,15 +312,15 @@ extension Manager {
                 let tempDirectoryURL = NSURL(fileURLWithPath: NSTemporaryDirectory())
                 let directoryURL = tempDirectoryURL.URLByAppendingPathComponent("com.alamofire.manager/multipart.form.data")
                 let fileName = NSUUID().UUIDString
-                let fileURL = directoryURL.URLByAppendingPathComponent(fileName)
+                let fileURL = directoryURL!.URLByAppendingPathComponent(fileName)
 
                 do {
-                    try fileManager.createDirectoryAtURL(directoryURL, withIntermediateDirectories: true, attributes: nil)
-                    try formData.writeEncodedDataToDisk(fileURL)
+                    try fileManager.createDirectoryAtURL(directoryURL!, withIntermediateDirectories: true, attributes: nil)
+                    try formData.writeEncodedDataToDisk(fileURL!)
 
                     dispatch_async(dispatch_get_main_queue()) {
                         let encodingResult = MultipartFormDataEncodingResult.Success(
-                            request: self.upload(URLRequestWithContentType, file: fileURL),
+                            request: self.upload(URLRequestWithContentType, file: fileURL!),
                             streamingFromDisk: true,
                             streamFileURL: fileURL
                         )

--- a/Pods/AlamofireImage/Source/UIImage+AlamofireImage.swift
+++ b/Pods/AlamofireImage/Source/UIImage+AlamofireImage.swift
@@ -106,7 +106,7 @@ extension UIImage {
         guard !af_inflated else { return }
 
         af_inflated = true
-        CGDataProviderCopyData(CGImageGetDataProvider(CGImage))
+        CGDataProviderCopyData(CGImageGetDataProvider(CGImage!)!)
     }
 }
 
@@ -115,7 +115,7 @@ extension UIImage {
 extension UIImage {
     /// Returns whether the image contains an alpha component.
     public var af_containsAlphaComponent: Bool {
-        let alphaInfo = CGImageGetAlphaInfo(CGImage)
+        let alphaInfo = CGImageGetAlphaInfo(CGImage!)
 
         return (
             alphaInfo == .First ||
@@ -146,7 +146,7 @@ extension UIImage {
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
-        return scaledImage
+        return scaledImage!
     }
 
     /**
@@ -183,7 +183,7 @@ extension UIImage {
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
-        return scaledImage
+        return scaledImage!
     }
 
     /**
@@ -215,7 +215,7 @@ extension UIImage {
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
-        return scaledImage
+        return scaledImage!
     }
 }
 
@@ -247,7 +247,7 @@ extension UIImage {
         let roundedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
-        return roundedImage
+        return roundedImage!
     }
 
     /**
@@ -279,7 +279,7 @@ extension UIImage {
         let roundedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
-        return roundedImage
+        return roundedImage!
     }
 }
 
@@ -318,7 +318,7 @@ extension UIImage {
 
         let cgImageRef = context.createCGImage(outputImage, fromRect: outputImage.extent)
 
-        return UIImage(CGImage: cgImageRef, scale: scale, orientation: imageOrientation)
+        return UIImage(CGImage: cgImageRef!, scale: scale, orientation: imageOrientation)
     }
 }
 

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -709,6 +709,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -738,6 +739,7 @@
 				PRODUCT_NAME = AlamofireNetworkActivityIndicator;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -767,6 +769,7 @@
 				PRODUCT_NAME = Alamofire;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -796,6 +799,7 @@
 				PRODUCT_NAME = AlamofireImage;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -906,6 +910,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1003,6 +1008,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1033,6 +1039,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1062,6 +1069,7 @@
 				PRODUCT_NAME = SwiftyJSON;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";


### PR DESCRIPTION
1) Updated all the frameworks to use Legacy Swift Language Version.
2) Used the latest enum value values for SecTrustResultType.
3) Updated code suggested by Xcode autocompletion (mostly forced unwrapping)
